### PR TITLE
Add rapid onboarding brief web app

### DIFF
--- a/t007_onboarding_brief/app.py
+++ b/t007_onboarding_brief/app.py
@@ -1,0 +1,108 @@
+"""Flask app for generating rapid onboarding briefs."""
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+
+from flask import Flask, Response, render_template, request
+
+from .export import to_markdown
+from .logic import parse_text
+
+app = Flask(__name__)
+app.secret_key = "rapid-onboard"
+
+_INPUT_LIMIT = 2000
+
+
+def _default_sections() -> Dict[str, Any]:
+    return {
+        "title": "Onboarding Brief",
+        "context": "",
+        "goals": [],
+        "constraints": [],
+        "stakeholders": [],
+        "unknowns": [],
+        "risks": [],
+        "week1_plan": [],
+    }
+
+
+@app.route("/", methods=["GET"])
+def home() -> str:
+    return render_template(
+        "index.html",
+        sections=None,
+        original_text="",
+        error=None,
+    )
+
+
+def _coerce_sections(raw: Dict[str, Any] | None) -> Dict[str, Any]:
+    sections = _default_sections()
+    if not raw:
+        return sections
+    for key in sections:
+        value = raw.get(key)
+        if key in {"context", "title"}:
+            sections[key] = str(value or "").strip()
+        elif isinstance(value, list):
+            sections[key] = [str(item).strip() for item in value if str(item).strip()]
+        elif value:
+            sections[key] = [str(value).strip()]
+    return sections
+
+
+@app.route("/brief", methods=["POST"])
+def brief() -> str:
+    text = request.form.get("text", "").strip()
+    if len(text) > _INPUT_LIMIT:
+        return render_template(
+            "index.html",
+            sections=None,
+            original_text=text[:_INPUT_LIMIT],
+            error="Trim input (2,000 char limit).",
+        )
+    if not text:
+        return render_template(
+            "index.html",
+            sections=None,
+            original_text="",
+            error="Provide kickoff notes to generate a brief.",
+        )
+    sections = parse_text(text)
+    section_json = json.dumps(sections)
+    return render_template(
+        "index.html",
+        sections=sections,
+        original_text=text,
+        error=None,
+        section_json=section_json,
+    )
+
+
+@app.route("/download.md", methods=["POST"])
+def download_markdown() -> Response:
+    section_data = request.form.get("section_data")
+    sections: Dict[str, Any] | None = None
+    if section_data:
+        try:
+            sections = json.loads(section_data)
+        except json.JSONDecodeError:
+            sections = None
+    if sections is None:
+        text = request.form.get("text", "")
+        sections = parse_text(text) if text else _default_sections()
+    normalized = _coerce_sections(sections)
+    markdown_bytes = to_markdown(normalized)
+    return Response(
+        markdown_bytes,
+        mimetype="text/markdown",
+        headers={
+            "Content-Disposition": "attachment; filename=onboarding_brief.md",
+        },
+    )
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/t007_onboarding_brief/export.py
+++ b/t007_onboarding_brief/export.py
@@ -1,0 +1,45 @@
+"""Utilities for exporting onboarding brief data."""
+from __future__ import annotations
+
+from typing import Dict, Iterable, List
+
+
+_SECTION_ORDER = [
+    ("context", "Context"),
+    ("goals", "Goals"),
+    ("constraints", "Constraints"),
+    ("stakeholders", "Stakeholders"),
+    ("unknowns", "Unknowns"),
+    ("risks", "Risks"),
+    ("week1_plan", "Week 1 Plan"),
+]
+
+
+def _ensure_list(items: Iterable[str] | None) -> List[str]:
+    if not items:
+        return []
+    return [str(item).strip() for item in items if str(item).strip()]
+
+
+def _format_list(items: Iterable[str]) -> List[str]:
+    values = _ensure_list(items)
+    if not values:
+        return ["- —"]
+    return [f"- {value}" for value in values]
+
+
+def to_markdown(sections: Dict[str, object]) -> bytes:
+    """Render the brief sections as Markdown and return UTF-8 encoded bytes."""
+    title = str(sections.get("title") or "Onboarding Brief").strip()
+    lines: List[str] = [f"# {title}", ""]
+    for key, label in _SECTION_ORDER:
+        lines.append(f"## {label}")
+        lines.append("")
+        if key == "context":
+            context = str(sections.get("context") or "—").strip() or "—"
+            lines.append(context)
+        else:
+            lines.extend(_format_list(sections.get(key)))
+        lines.append("")
+    markdown = "\n".join(lines).strip() + "\n"
+    return markdown.encode("utf-8")

--- a/t007_onboarding_brief/logic.py
+++ b/t007_onboarding_brief/logic.py
@@ -1,0 +1,305 @@
+"""Rule-based parser for onboarding brief sections."""
+from __future__ import annotations
+
+import re
+from typing import Iterable, List
+
+
+def sentence_split(text: str) -> List[str]:
+    """Split raw text into sentences using simple punctuation boundaries."""
+    if not text:
+        return []
+    normalized = re.sub(r"\s+", " ", text.strip())
+    # Split on punctuation that typically ends a sentence.
+    parts = re.split(r"(?<=[.!?])\s+", normalized)
+    sentences = [part.strip() for part in parts if part.strip()]
+    return sentences
+
+
+def _first_nonempty_line(text: str) -> str | None:
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped:
+            return stripped
+    return None
+
+
+def extract_title(text: str) -> str:
+    """Return a brief title derived from the first sentence or line."""
+    first_sentence = next(iter(sentence_split(text)), "")
+    candidate = first_sentence.rstrip(". ") if first_sentence else None
+    if not candidate:
+        candidate = _first_nonempty_line(text) or "Onboarding Brief"
+    if len(candidate) > 90:
+        return "Onboarding Brief"
+    # Append suffix if missing to reinforce artifact type.
+    suffix = "– Onboarding Brief"
+    if "brief" in candidate.lower():
+        return candidate
+    return f"{candidate} {suffix}".strip()
+
+
+_GOAL_RE = re.compile(r"\b(goal|target|deliver|okr|kpi|outcome)s?\b", re.IGNORECASE)
+_CONSTRAINT_RE = re.compile(
+    r"\b(budget|budgets|deadline|deadlines|timeline|timelines|scope|scopes|constraint|constraints|compliance|security|tech|"
+    r"technology|data|dependency|dependencies)\b",
+    re.IGNORECASE,
+)
+_UNKNOWN_RE = re.compile(r"\b(unknown|unclear|tbd|open question)\b|\?", re.IGNORECASE)
+_RISK_RE = re.compile(
+    r"\b(risk|blocker|fail|dependency|legal|security|churn|outage|delay|issue|limit)\b",
+    re.IGNORECASE,
+)
+_GOAL_LABEL_RE = re.compile(r"(goal|target|deliver|okr|kpi|outcome)s?:", re.IGNORECASE)
+_CONSTRAINT_LABEL_RE = re.compile(
+    r"(constraint|budget|deadline|timeline|scope|compliance|security|tech|data|dependency)s?:",
+    re.IGNORECASE,
+)
+_UNKNOWN_LABEL_RE = re.compile(r"(unknown|unclear|tbd|open question)s?:", re.IGNORECASE)
+_RISK_LABEL_RE = re.compile(r"(risk|blocker|dependency|legal|security|churn|outage|fail)s?:", re.IGNORECASE)
+_STAKEHOLDER_LABEL_RE = re.compile(r"(stakeholder|sponsor|owner)s?:", re.IGNORECASE)
+
+
+def _clean_prefix(text: str) -> str:
+    return re.sub(r"^(goal[s]?|constraint[s]?|unknowns?|risks?|notes?):\s*",
+                  "", text, flags=re.IGNORECASE)
+
+
+def extract_context(sentences: Iterable[str]) -> str:
+    """Select one to two sentences that provide project context."""
+    context: List[str] = []
+    exclusion_patterns = (
+        _GOAL_RE,
+        _CONSTRAINT_RE,
+        _UNKNOWN_RE,
+        _RISK_RE,
+        _STAKEHOLDER_LABEL_RE,
+    )
+    for sentence in sentences:
+        if any(pattern.search(sentence) for pattern in exclusion_patterns):
+            continue
+        cleaned = sentence.strip()
+        if cleaned:
+            context.append(cleaned)
+        if len(context) == 2:
+            break
+    if not context and sentences:
+        first = next(iter(sentences))
+        if first:
+            context.append(first.strip())
+    return " ".join(context)
+
+
+def extract_goals(chunks: Iterable[str]) -> List[str]:
+    goals: List[str] = []
+    for chunk in chunks:
+        if not _GOAL_RE.search(chunk):
+            continue
+        body = chunk
+        label = _GOAL_LABEL_RE.search(chunk)
+        if label:
+            body = chunk[label.end() :]
+        pieces = re.split(r"[.;\n]\s*", body)
+        for piece in pieces:
+            candidate = _clean_prefix(piece).strip(" -•")
+            if not candidate:
+                continue
+            lower = candidate.lower()
+            if any(
+                token in lower
+                for token in (
+                    "unknown",
+                    "risk",
+                    "constraint",
+                    "stakeholder",
+                    "budget",
+                    "deadline",
+                    "timeline",
+                    "scope",
+                )
+            ):
+                continue
+            candidate = candidate.rstrip(". ")
+            if candidate:
+                normalized = candidate[0].upper() + candidate[1:] if candidate else candidate
+                if normalized not in goals:
+                    goals.append(normalized)
+            if len(goals) >= 3:
+                break
+        if len(goals) >= 3:
+            break
+    return goals[:3]
+
+
+def extract_constraints(chunks: Iterable[str]) -> List[str]:
+    constraints: List[str] = []
+    for chunk in chunks:
+        match = _CONSTRAINT_RE.search(chunk)
+        if not match:
+            continue
+        keyword = match.group(0).lower()
+        body = chunk
+        label = _CONSTRAINT_LABEL_RE.search(chunk)
+        if label:
+            body = chunk[label.end() :]
+        elif keyword in {"tech", "technology", "data"}:
+            # Avoid treating generic mentions as constraints without a label.
+            continue
+        pieces = re.split(r"[,;\n]\s*", body)
+        if not label:
+            pieces = [body]
+        for piece in pieces:
+            candidate = _clean_prefix(piece).strip(" -•")
+            if not candidate:
+                continue
+            lower = candidate.lower()
+            stop_after = False
+            for marker in ("stakeholders", "unknowns", "risks", "goals"):
+                if marker in lower:
+                    candidate = candidate.split(marker, 1)[0].strip(" -•. ")
+                    stop_after = True
+                    lower = candidate.lower()
+                    break
+            if any(token in lower for token in ("unknown", "risk", "stakeholder", "goal")):
+                if stop_after:
+                    break
+                continue
+            candidate = candidate.rstrip(". ")
+            if candidate and candidate not in constraints:
+                constraints.append(candidate)
+            if len(constraints) >= 5:
+                break
+            if stop_after:
+                break
+        if len(constraints) >= 5:
+            break
+    return constraints[:5]
+
+
+_STAKEHOLDER_NAME_ROLE_RE = re.compile(
+    r"(?P<name>[A-Z][A-Za-z'.-]+(?:\s+[A-Z][A-Za-z'.-]+)+)\s*[–-]\s*(?P<role>[^,;]+)"
+)
+_PAREN_ROLE_RE = re.compile(r"([A-Z][A-Za-z'.-]+)\s*\(([^)]+)\)")
+_EMAIL_RE = re.compile(r"[A-Za-z0-9_.+-]+@[A-Za-z0-9_.-]+\.[A-Za-z]{2,}")
+_TITLED_NAME_RE = re.compile(r"\b[A-Z][a-z]+\s+[A-Z][a-z]+\b")
+
+
+def extract_stakeholders(text: str) -> List[str]:
+    found: List[str] = []
+    seen = set()
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    for line in lines:
+        lower_line = line.lower()
+        for name, role in _PAREN_ROLE_RE.findall(line):
+            label = f"{name} – {role.strip()}"
+            if label not in seen:
+                seen.add(label)
+                found.append(label)
+        for match in _STAKEHOLDER_NAME_ROLE_RE.finditer(line):
+            label = f"{match.group('name')} – {match.group('role').strip()}"
+            if label not in seen:
+                seen.add(label)
+                found.append(label)
+        for email in _EMAIL_RE.findall(line):
+            if email not in seen:
+                seen.add(email)
+                found.append(email)
+        if any(token in lower_line for token in ("stakeholder", "owner", "sponsor")):
+            for name in _TITLED_NAME_RE.findall(line):
+                if name not in seen:
+                    seen.add(name)
+                    found.append(name)
+        if len(found) >= 8:
+            break
+    return found[:8]
+
+
+def extract_unknowns(sentences: Iterable[str]) -> List[str]:
+    unknowns: List[str] = []
+    for sentence in sentences:
+        if _UNKNOWN_RE.search(sentence):
+            body = sentence
+            label = _UNKNOWN_LABEL_RE.search(sentence)
+            if label:
+                body = sentence[label.end() :]
+            parts = re.split(r"[?•\u2022]\s*", body)
+            for part in parts:
+                cleaned = _clean_prefix(part).strip(" -•")
+                if not cleaned:
+                    continue
+                cleaned = cleaned.rstrip("?. ")
+                if not cleaned:
+                    continue
+                text = cleaned[0].upper() + cleaned[1:] if cleaned else cleaned
+                if not text:
+                    continue
+                if not text.lower().startswith("clarify"):
+                    text = f"Clarify {text}".strip()
+                if not text.endswith('.'):
+                    text = f"{text}."
+                if text not in unknowns:
+                    unknowns.append(text)
+    return unknowns
+
+
+def extract_risks(sentences: Iterable[str]) -> List[str]:
+    risks: List[str] = []
+    for sentence in sentences:
+        if _RISK_RE.search(sentence):
+            body = sentence
+            label = _RISK_LABEL_RE.search(sentence)
+            if label:
+                body = sentence[label.end() :]
+            pieces = re.split(r"[;•\u2022]\s*", body)
+            if not label:
+                pieces = [body]
+            for piece in pieces:
+                candidate = _clean_prefix(piece).strip(" -•")
+                if not candidate:
+                    continue
+                lower = candidate.lower()
+                if "unknown" in lower:
+                    continue
+                candidate = re.sub(r"\s+", " ", candidate).rstrip(". ")
+                if candidate and candidate not in risks:
+                    risks.append(candidate)
+    return risks
+
+
+def make_week1_plan(goals: List[str], risks: List[str], stakeholders: List[str]) -> List[str]:
+    primary = stakeholders[0] if stakeholders else "primary stakeholder"
+    step1 = f"Confirm goals/constraints with {primary}."
+    step2 = "Get access to systems/data + create success metric."
+    if goals:
+        primary_goal = goals[0].rstrip('. ')
+        step2 = f"Get access to systems/data + define metric for '{primary_goal}'."
+    if risks:
+        risk_summary = risks[0].rstrip('. ')
+        step3 = f"Ship Day-5 brief: status, risks, decision needed (watch '{risk_summary}')."
+    else:
+        step3 = "Ship Day-5 brief: status, risks, decision needed."
+    return [step1, step2, step3]
+
+
+def parse_text(text: str) -> dict:
+    sentences = sentence_split(text)
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    combined = list(dict.fromkeys(sentences + lines)) if sentences else lines
+    title = extract_title(text)
+    context = extract_context(sentences)
+    goals = extract_goals(combined or sentences)
+    constraints = extract_constraints(combined or sentences)
+    stakeholders = extract_stakeholders(text)
+    unknowns = extract_unknowns(sentences)
+    risks = extract_risks(sentences)
+    week1_plan = make_week1_plan(goals, risks, stakeholders)
+    return {
+        "title": title or "Onboarding Brief",
+        "context": context,
+        "goals": goals,
+        "constraints": constraints,
+        "stakeholders": stakeholders,
+        "unknowns": unknowns,
+        "risks": risks,
+        "week1_plan": week1_plan,
+    }

--- a/t007_onboarding_brief/static/ui.js
+++ b/t007_onboarding_brief/static/ui.js
@@ -1,0 +1,137 @@
+(function () {
+  if (typeof window === 'undefined' || typeof window.initialSections === 'undefined') {
+    return;
+  }
+
+  const sectionField = document.getElementById('section-data');
+  const copyButton = document.getElementById('copy-brief');
+  const copyFeedback = document.getElementById('copy-feedback');
+  const downloadForm = document.getElementById('download-form');
+
+  let sections;
+  try {
+    sections = JSON.parse(JSON.stringify(window.initialSections || {}));
+  } catch (err) {
+    sections = {};
+  }
+
+  const SECTION_ORDER = [
+    ['context', 'Context'],
+    ['goals', 'Goals'],
+    ['constraints', 'Constraints'],
+    ['stakeholders', 'Stakeholders'],
+    ['unknowns', 'Unknowns'],
+    ['risks', 'Risks'],
+    ['week1_plan', 'Week 1 Plan'],
+  ];
+
+  function syncField() {
+    if (!sectionField) {
+      return;
+    }
+    sectionField.value = JSON.stringify(sections);
+  }
+
+  function ensureArray(key) {
+    if (!Array.isArray(sections[key])) {
+      sections[key] = [];
+    }
+    return sections[key];
+  }
+
+  document.querySelectorAll('[data-section-list]').forEach((list) => {
+    const key = list.getAttribute('data-section-key');
+    if (!key) {
+      return;
+    }
+    const items = list.querySelectorAll('li[contenteditable="true"]');
+    items.forEach((item) => {
+      const index = parseInt(item.dataset.index || '0', 10);
+      const values = ensureArray(key);
+      if (typeof values[index] === 'undefined') {
+        values[index] = item.textContent.trim();
+      }
+      const updateFromContent = () => {
+        const text = item.textContent.trim();
+        values[index] = text || '—';
+        if (!text) {
+          item.textContent = '—';
+          item.dataset.placeholder = 'true';
+        } else if (item.dataset.placeholder) {
+          delete item.dataset.placeholder;
+        }
+        syncField();
+      };
+      item.addEventListener('blur', updateFromContent);
+      item.addEventListener('input', () => {
+        const text = item.textContent;
+        values[index] = text.trim();
+        syncField();
+      });
+    });
+  });
+
+  function buildMarkdown(data) {
+    const clone = Object.assign({}, data);
+    const lines = [`# ${clone.title || 'Onboarding Brief'}`, ''];
+    SECTION_ORDER.forEach(([key, label]) => {
+      lines.push(`## ${label}`);
+      lines.push('');
+      if (key === 'context') {
+        const context = (clone.context || '').toString().trim();
+        lines.push(context || '—');
+      } else {
+        const items = Array.isArray(clone[key]) ? clone[key] : [];
+        if (!items.length || items.every((item) => !item || !item.toString().trim())) {
+          lines.push('- —');
+        } else {
+          items.forEach((item) => {
+            const value = (item || '').toString().trim();
+            lines.push(`- ${value || '—'}`);
+          });
+        }
+      }
+      lines.push('');
+    });
+    return lines.join('\n').trim() + '\n';
+  }
+
+  async function copyMarkdown() {
+    const markdown = buildMarkdown(sections);
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      try {
+        await navigator.clipboard.writeText(markdown);
+        if (copyFeedback) {
+          copyFeedback.classList.add('visible');
+          setTimeout(() => copyFeedback.classList.remove('visible'), 1600);
+        }
+        return;
+      } catch (err) {
+        // fall through to textarea copy
+      }
+    }
+    const temp = document.createElement('textarea');
+    temp.value = markdown;
+    temp.setAttribute('readonly', 'true');
+    temp.style.position = 'absolute';
+    temp.style.left = '-9999px';
+    document.body.appendChild(temp);
+    temp.select();
+    document.execCommand('copy');
+    document.body.removeChild(temp);
+    if (copyFeedback) {
+      copyFeedback.classList.add('visible');
+      setTimeout(() => copyFeedback.classList.remove('visible'), 1600);
+    }
+  }
+
+  if (copyButton) {
+    copyButton.addEventListener('click', copyMarkdown);
+  }
+
+  if (downloadForm) {
+    downloadForm.addEventListener('submit', syncField);
+  }
+
+  syncField();
+})();

--- a/t007_onboarding_brief/templates/index.html
+++ b/t007_onboarding_brief/templates/index.html
@@ -1,0 +1,232 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Rapid Onboarding Brief</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: "Inter", "Segoe UI", sans-serif;
+      }
+      body {
+        margin: 0;
+        padding: 0;
+        background: #f7f7f9;
+        color: #1b1b1f;
+      }
+      .container {
+        max-width: 900px;
+        margin: 0 auto;
+        padding: 2rem 1.5rem 4rem;
+      }
+      h1 {
+        margin-bottom: 1rem;
+      }
+      form textarea {
+        width: 100%;
+        min-height: 180px;
+        padding: 0.75rem;
+        border-radius: 8px;
+        border: 1px solid #d0d0d5;
+        font-size: 1rem;
+        resize: vertical;
+      }
+      label {
+        font-weight: 600;
+        display: block;
+        margin-bottom: 0.5rem;
+      }
+      .controls {
+        margin-top: 0.75rem;
+        display: flex;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+      button {
+        background: #1c3faa;
+        color: white;
+        border: none;
+        border-radius: 6px;
+        padding: 0.6rem 1.2rem;
+        font-size: 0.95rem;
+        cursor: pointer;
+      }
+      button.secondary {
+        background: #e4e4e9;
+        color: #1b1b1f;
+      }
+      .error {
+        background: #ffe1e1;
+        border: 1px solid #ff9a9a;
+        padding: 0.75rem;
+        border-radius: 6px;
+        margin-top: 1rem;
+        color: #7f1d1d;
+      }
+      .brief {
+        margin-top: 2.5rem;
+        background: white;
+        border-radius: 12px;
+        padding: 1.75rem;
+        box-shadow: 0 12px 30px rgba(0, 0, 0, 0.06);
+      }
+      .brief h2 {
+        margin-top: 0;
+        font-size: 1.6rem;
+      }
+      .section {
+        margin-top: 1.5rem;
+      }
+      .section h3 {
+        margin-bottom: 0.5rem;
+        font-size: 1.1rem;
+        letter-spacing: 0.02em;
+        text-transform: uppercase;
+      }
+      .section p {
+        margin: 0;
+        line-height: 1.5;
+      }
+      ul {
+        margin: 0;
+        padding-left: 1.2rem;
+        display: grid;
+        gap: 0.4rem;
+      }
+      li[contenteditable="true"] {
+        border-bottom: 1px dashed transparent;
+      }
+      li[contenteditable="true"]:focus {
+        outline: none;
+        border-color: #1c3faa;
+      }
+      .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        margin-top: 1.5rem;
+      }
+      .copy-feedback {
+        font-size: 0.9rem;
+        color: #1c3faa;
+        display: none;
+        align-items: center;
+      }
+      .copy-feedback.visible {
+        display: inline-flex;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <h1>T-007 · Rapid Onboarding Brief</h1>
+      <p>Paste kickoff notes to generate a client-ready onboarding brief in minutes.</p>
+      <form method="post" action="{{ url_for('brief') }}">
+        <label for="text">Kickoff notes (limit 2,000 characters)</label>
+        <textarea id="text" name="text" maxlength="2000" placeholder="Paste kickoff notes here...">{{ original_text }}</textarea>
+        <div class="controls">
+          <button type="submit">Generate brief</button>
+        </div>
+      </form>
+      {% if error %}
+        <div class="error">{{ error }}</div>
+      {% endif %}
+
+      {% if sections %}
+      <div class="brief" id="brief">
+        <h2>{{ sections.title or 'Onboarding Brief' }}</h2>
+        <div class="section">
+          <h3>Context</h3>
+          <p id="context">{{ sections.context or '—' }}</p>
+        </div>
+        <div class="section">
+          <h3>Goals</h3>
+          <ul id="goals" data-section-key="goals" data-section-list>
+            {% if sections.goals %}
+              {% for item in sections.goals %}
+                <li contenteditable="true" data-index="{{ loop.index0 }}">{{ item }}</li>
+              {% endfor %}
+            {% else %}
+              <li class="placeholder">—</li>
+            {% endif %}
+          </ul>
+        </div>
+        <div class="section">
+          <h3>Constraints</h3>
+          <ul id="constraints" data-section-key="constraints" data-section-list>
+            {% if sections.constraints %}
+              {% for item in sections.constraints %}
+                <li contenteditable="true" data-index="{{ loop.index0 }}">{{ item }}</li>
+              {% endfor %}
+            {% else %}
+              <li class="placeholder">—</li>
+            {% endif %}
+          </ul>
+        </div>
+        <div class="section">
+          <h3>Stakeholders</h3>
+          <ul id="stakeholders" data-section-key="stakeholders" data-section-list>
+            {% if sections.stakeholders %}
+              {% for item in sections.stakeholders %}
+                <li contenteditable="true" data-index="{{ loop.index0 }}">{{ item }}</li>
+              {% endfor %}
+            {% else %}
+              <li class="placeholder">—</li>
+            {% endif %}
+          </ul>
+        </div>
+        <div class="section">
+          <h3>Unknowns</h3>
+          <ul id="unknowns" data-section-key="unknowns" data-section-list>
+            {% if sections.unknowns %}
+              {% for item in sections.unknowns %}
+                <li contenteditable="true" data-index="{{ loop.index0 }}">{{ item }}</li>
+              {% endfor %}
+            {% else %}
+              <li class="placeholder">—</li>
+            {% endif %}
+          </ul>
+        </div>
+        <div class="section">
+          <h3>Risks</h3>
+          <ul id="risks" data-section-key="risks" data-section-list>
+            {% if sections.risks %}
+              {% for item in sections.risks %}
+                <li contenteditable="true" data-index="{{ loop.index0 }}">{{ item }}</li>
+              {% endfor %}
+            {% else %}
+              <li class="placeholder">—</li>
+            {% endif %}
+          </ul>
+        </div>
+        <div class="section">
+          <h3>Week 1 Plan</h3>
+          <ul id="week1_plan" data-section-key="week1_plan" data-section-list>
+            {% if sections.week1_plan %}
+              {% for item in sections.week1_plan %}
+                <li contenteditable="true" data-index="{{ loop.index0 }}">{{ item }}</li>
+              {% endfor %}
+            {% else %}
+              <li class="placeholder">—</li>
+            {% endif %}
+          </ul>
+        </div>
+        <div class="actions">
+          <form id="download-form" method="post" action="{{ url_for('download_markdown') }}">
+            <input type="hidden" name="text" value="{{ original_text }}">
+            <textarea id="section-data" name="section_data" hidden>{{ section_json }}</textarea>
+            <button type="submit">Download .md</button>
+          </form>
+          <button type="button" class="secondary" id="copy-brief">Copy Markdown</button>
+          <span class="copy-feedback" id="copy-feedback">Copied!</span>
+        </div>
+      </div>
+      <script>
+        window.initialSections = {{ section_json | safe }};
+      </script>
+      <script src="{{ url_for('static', filename='ui.js') }}"></script>
+      {% endif %}
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- build the T-007 onboarding brief Flask blueprint with routes for parsing kickoff notes and exporting markdown
- implement the rule-based parsing heuristics for goals, constraints, stakeholders, unknowns, risks, and week-one plan generation
- add HTML/CSS/JS for inline edits plus copy/download controls backed by markdown exporter

## Testing
- python -m compileall t007_onboarding_brief

------
https://chatgpt.com/codex/tasks/task_e_68c95a71c35c832686d382366d040800